### PR TITLE
compatibility-v4 version 13

### DIFF
--- a/android-sample-tests/pom.xml
+++ b/android-sample-tests/pom.xml
@@ -69,7 +69,7 @@
 		<dependency>
 			<groupId>android.support</groupId>
 			<artifactId>compatibility-v4</artifactId>
-			<version>12</version>
+			<version>13</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Updated compatibility-v4 to use version 13, which is installed by maven-android-sdk-deployer
