### PR TITLE
Fixed broken jacoco profile dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		<platform.version>4.2.2_r2</platform.version>
 		<java.version>1.6</java.version>
 		<android.sdk.version>17</android.sdk.version>
-		<android.support.version>18</android.support.version>
+		<android.support.version>19</android.support.version>
 
 		<!-- Compile Dependencies -->
 		<joda.version>2.2</joda.version>
@@ -36,7 +36,7 @@
 
 		<!-- Plugins -->
 		<maven-compiler-plugin.version>2.5.1</maven-compiler-plugin.version>
-		<android-maven-plugin.version>3.6.1</android-maven-plugin.version>
+		<android-maven-plugin.version>3.8.2</android-maven-plugin.version>
 		<cobertura.version>2.5.2</cobertura.version>
 		<maven-pmd-plugin.version>2.7.1</maven-pmd-plugin.version>
 		<findbugs-maven-plugin.version>2.5.2</findbugs-maven-plugin.version>


### PR DESCRIPTION
The README says to install compatibility-v4, but that installs version 19 now, and the pom required version 18.
When using maven-android-plugin 3.6.1, I got a NoClassDefFoundError for org.sonatype.aether.RepositorySystem. Upgrading to 3.8.2 fixed that.

This doesn't fix the `mvn clean install -P jacoco` build. There are still test failures, but I want that to be a separate commit since it's a different problem.

Full output for the individual errors is included below.

compatibility-v4 error:

```
LT-A8-120617:Quality-Tools-for-Android heath.borders$ mvn clean install -P jacoco
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for com.octo.android:android-sample-tests:apk:0.0.1-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-compiler-plugin @ line 113, column 12
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:build-helper-maven-plugin is missing. @ line 95, column 12
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO]
[INFO] android-sample-parent
[INFO] android-sample
[INFO] android-sample-tests
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building android-sample-parent 0.0.1-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ android-sample-parent ---
[INFO]
[INFO] --- lint-maven-plugin:0.0.6:check (default) @ android-sample-parent ---
PROFILES: [Profile {id: default, source: pom}, Profile {id: emma, source: pom}, Profile {id: cobertura, source: pom}, Profile {id: uiautomator, source: pom}, Profile {id: espresso, source: pom}, Profile {id: spoon, source: pom}, Profile {id: jacoco, source: pom}, Profile {id: monkey, source: pom}, Profile {id: cycle, source: pom}, Profile {id: monkeyrunner, source: pom}]
[INFO] Writing summary report
[INFO] [LINT] Completed with no violations
[INFO] Writing xml report
[INFO]
[INFO] --- maven-install-plugin:2.4:install (default-install) @ android-sample-parent ---
[INFO] Installing /Users/heath.borders/workspace/Quality-Tools-for-Android/pom.xml to /Users/heath.borders/.m2/repository/com/octo/android/android-sample-parent/0.0.1-SNAPSHOT/android-sample-parent-0.0.1-SNAPSHOT.pom
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building android-sample 0.0.1-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[WARNING] The POM for android.support:compatibility-v4:jar:18 is missing, no dependency information available
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] android-sample-parent ............................. SUCCESS [1.305s]
[INFO] android-sample .................................... FAILURE [0.290s]
[INFO] android-sample-tests .............................. SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 2.452s
[INFO] Finished at: Tue Jun 10 10:15:13 CDT 2014
[INFO] Final Memory: 10M/81M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project android-sample: Could not resolve dependencies for project com.octo.android:android-sample:apk:0.0.1-SNAPSHOT: Failure to find android.support:compatibility-v4:jar:18 in http://nexus-int.eng.jiveland.com/content/groups/public was cached in the local repository, resolution will not be reattempted until the update interval of nexus-server has elapsed or updates are forced -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :android-sample
```

maven-android-plugin error:

```
LT-A8-120617:Quality-Tools-for-Android heath.borders$ mvn clean install -P jacoco
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for com.octo.android:android-sample-tests:apk:0.0.1-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-compiler-plugin @ line 113, column 12
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:build-helper-maven-plugin is missing. @ line 95, column 12
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO]
[INFO] android-sample-parent
[INFO] android-sample
[INFO] android-sample-tests
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building android-sample-parent 0.0.1-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ android-sample-parent ---
[INFO] Deleting /Users/heath.borders/workspace/Quality-Tools-for-Android/target
[INFO]
[INFO] --- lint-maven-plugin:0.0.6:check (default) @ android-sample-parent ---
PROFILES: [Profile {id: default, source: pom}, Profile {id: emma, source: pom}, Profile {id: cobertura, source: pom}, Profile {id: uiautomator, source: pom}, Profile {id: espresso, source: pom}, Profile {id: spoon, source: pom}, Profile {id: jacoco, source: pom}, Profile {id: monkey, source: pom}, Profile {id: cycle, source: pom}, Profile {id: monkeyrunner, source: pom}]
[INFO] Writing summary report
[INFO] [LINT] Completed with no violations
[INFO] Writing xml report
[INFO]
[INFO] --- maven-install-plugin:2.4:install (default-install) @ android-sample-parent ---
[INFO] Installing /Users/heath.borders/workspace/Quality-Tools-for-Android/pom.xml to /Users/heath.borders/.m2/repository/com/octo/android/android-sample-parent/0.0.1-SNAPSHOT/android-sample-parent-0.0.1-SNAPSHOT.pom
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building android-sample 0.0.1-SNAPSHOT
[INFO] ------------------------------------------------------------------------
Downloading: http://nexus-int.eng.jiveland.com/content/groups/public/android/support/compatibility-v4/19/compatibility-v4-19.pom
Downloaded: http://nexus-int.eng.jiveland.com/content/groups/public/android/support/compatibility-v4/19/compatibility-v4-19.pom (401 B at 0.1 KB/sec)
Downloading: http://nexus-int.eng.jiveland.com/content/groups/public/android/support/compatibility-v4/19/compatibility-v4-19.jar
Downloaded: http://nexus-int.eng.jiveland.com/content/groups/public/android/support/compatibility-v4/19/compatibility-v4-19.jar (607 KB at 146.3 KB/sec)
[INFO]
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ android-sample ---
[INFO]
[INFO] --- lint-maven-plugin:0.0.6:check (default) @ android-sample ---
PROFILES: [Profile {id: default, source: pom}, Profile {id: emma, source: pom}, Profile {id: cobertura, source: pom}, Profile {id: uiautomator, source: pom}, Profile {id: spoon, source: pom}, Profile {id: jacoco, source: pom}, Profile {id: monkey, source: pom}, Profile {id: cycle, source: pom}, Profile {id: monkeyrunner, source: pom}]
[INFO] Writing summary report
[INFO] [LINT] Completed with no violations
[INFO] Writing xml report
[INFO]
[INFO] --- android-maven-plugin:3.6.1:generate-sources (default-generate-sources) @ android-sample ---
[WARNING] Error injecting: com.jayway.maven.plugins.android.phase01generatesources.GenerateSourcesMojo
java.lang.NoClassDefFoundError: Lorg/sonatype/aether/RepositorySystem;
    at java.lang.Class.getDeclaredFields0(Native Method)
    at java.lang.Class.privateGetDeclaredFields(Class.java:2348)
    at java.lang.Class.getDeclaredFields(Class.java:1779)
    at com.google.inject.spi.InjectionPoint.getInjectionPoints(InjectionPoint.java:661)
    at com.google.inject.spi.InjectionPoint.forInstanceMethodsAndFields(InjectionPoint.java:366)
    at com.google.inject.internal.ConstructorBindingImpl.getInternalDependencies(ConstructorBindingImpl.java:165)
    at com.google.inject.internal.InjectorImpl.getInternalDependencies(InjectorImpl.java:609)
    at com.google.inject.internal.InjectorImpl.cleanup(InjectorImpl.java:565)
    at com.google.inject.internal.InjectorImpl.initializeJitBinding(InjectorImpl.java:551)
    at com.google.inject.internal.InjectorImpl.createJustInTimeBinding(InjectorImpl.java:865)
    at com.google.inject.internal.InjectorImpl.createJustInTimeBindingRecursive(InjectorImpl.java:790)
    at com.google.inject.internal.InjectorImpl.getJustInTimeBinding(InjectorImpl.java:278)
    at com.google.inject.internal.InjectorImpl.getBindingOrThrow(InjectorImpl.java:210)
    at com.google.inject.internal.InjectorImpl.getProviderOrThrow(InjectorImpl.java:986)
    at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:1019)
    at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:982)
    at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1032)
    at org.eclipse.sisu.space.AbstractDeferredClass.get(AbstractDeferredClass.java:48)
    at com.google.inject.internal.ProviderInternalFactory.provision(ProviderInternalFactory.java:86)
    at com.google.inject.internal.InternalFactoryToInitializableAdapter.provision(InternalFactoryToInitializableAdapter.java:55)
    at com.google.inject.internal.ProviderInternalFactory$1.call(ProviderInternalFactory.java:70)
    at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:100)
    at org.eclipse.sisu.plexus.PlexusLifecycleManager.onProvision(PlexusLifecycleManager.java:133)
    at com.google.inject.internal.ProvisionListenerStackCallback$Provision.provision(ProvisionListenerStackCallback.java:109)
    at com.google.inject.internal.ProvisionListenerStackCallback.provision(ProvisionListenerStackCallback.java:55)
    at com.google.inject.internal.ProviderInternalFactory.circularGet(ProviderInternalFactory.java:68)
    at com.google.inject.internal.InternalFactoryToInitializableAdapter.get(InternalFactoryToInitializableAdapter.java:47)
    at com.google.inject.internal.InjectorImpl$2$1.call(InjectorImpl.java:997)
    at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1047)
    at com.google.inject.internal.InjectorImpl$2.get(InjectorImpl.java:993)
    at com.google.inject.Scopes$1$1.get(Scopes.java:59)
    at org.eclipse.sisu.inject.LazyBeanEntry.getValue(LazyBeanEntry.java:82)
    at org.eclipse.sisu.plexus.LazyPlexusBean.getValue(LazyPlexusBean.java:51)
    at org.codehaus.plexus.DefaultPlexusContainer.lookup(DefaultPlexusContainer.java:260)
    at org.codehaus.plexus.DefaultPlexusContainer.lookup(DefaultPlexusContainer.java:252)
    at org.apache.maven.plugin.internal.DefaultMavenPluginManager.getConfiguredMojo(DefaultMavenPluginManager.java:459)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:97)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
    at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:317)
    at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:152)
    at org.apache.maven.cli.MavenCli.execute(MavenCli.java:555)
    at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:214)
    at org.apache.maven.cli.MavenCli.main(MavenCli.java:158)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: java.lang.ClassNotFoundException: org.sonatype.aether.RepositorySystem
    at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass(SelfFirstStrategy.java:50)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass(ClassRealm.java:259)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:242)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass(ClassRealm.java:227)
    ... 57 more
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] android-sample-parent ............................. SUCCESS [1.386s]
[INFO] android-sample .................................... FAILURE [9.698s]
[INFO] android-sample-tests .............................. SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 12.044s
[INFO] Finished at: Tue Jun 10 10:21:52 CDT 2014
[INFO] Final Memory: 13M/81M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.jayway.maven.plugins.android.generation2:android-maven-plugin:3.6.1:generate-sources (default-generate-sources) on project android-sample: Execution default-generate-sources of goal com.jayway.maven.plugins.android.generation2:android-maven-plugin:3.6.1:generate-sources failed: A required class was missing while executing com.jayway.maven.plugins.android.generation2:android-maven-plugin:3.6.1:generate-sources: Lorg/sonatype/aether/RepositorySystem;
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>com.jayway.maven.plugins.android.generation2:android-maven-plugin:3.6.1
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/Users/heath.borders/.m2/repository/com/jayway/maven/plugins/android/generation2/android-maven-plugin/3.6.1/android-maven-plugin-3.6.1.jar
[ERROR] urls[1] = file:/Users/heath.borders/.m2/repository/com/android/tools/build/builder/0.4.2/builder-0.4.2.jar
[ERROR] urls[2] = file:/Users/heath.borders/.m2/repository/com/android/tools/sdklib/22.0.2/sdklib-22.0.2.jar
[ERROR] urls[3] = file:/Users/heath.borders/.m2/repository/com/android/tools/layoutlib/layoutlib-api/22.0.2/layoutlib-api-22.0.2.jar
[ERROR] urls[4] = file:/Users/heath.borders/.m2/repository/com/android/tools/dvlib/22.0.2/dvlib-22.0.2.jar
[ERROR] urls[5] = file:/Users/heath.borders/.m2/repository/org/apache/httpcomponents/httpclient/4.1.1/httpclient-4.1.1.jar
[ERROR] urls[6] = file:/Users/heath.borders/.m2/repository/org/apache/httpcomponents/httpcore/4.1/httpcore-4.1.jar
[ERROR] urls[7] = file:/Users/heath.borders/.m2/repository/commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.jar
[ERROR] urls[8] = file:/Users/heath.borders/.m2/repository/commons-codec/commons-codec/1.4/commons-codec-1.4.jar
[ERROR] urls[9] = file:/Users/heath.borders/.m2/repository/org/apache/httpcomponents/httpmime/4.1/httpmime-4.1.jar
[ERROR] urls[10] = file:/Users/heath.borders/.m2/repository/org/apache/commons/commons-compress/1.0/commons-compress-1.0.jar
[ERROR] urls[11] = file:/Users/heath.borders/.m2/repository/com/android/tools/sdk-common/22.0.2/sdk-common-22.0.2.jar
[ERROR] urls[12] = file:/Users/heath.borders/.m2/repository/com/android/tools/build/builder-model/0.4.2/builder-model-0.4.2.jar
[ERROR] urls[13] = file:/Users/heath.borders/.m2/repository/com/android/tools/common/22.0.2/common-22.0.2.jar
[ERROR] urls[14] = file:/Users/heath.borders/.m2/repository/com/google/guava/guava/13.0.1/guava-13.0.1.jar
[ERROR] urls[15] = file:/Users/heath.borders/.m2/repository/com/android/tools/build/builder-test-api/0.4.2/builder-test-api-0.4.2.jar
[ERROR] urls[16] = file:/Users/heath.borders/.m2/repository/com/android/tools/build/manifest-merger/22.0.2/manifest-merger-22.0.2.jar
[ERROR] urls[17] = file:/Users/heath.borders/.m2/repository/net/sf/kxml/kxml2/2.3.0/kxml2-2.3.0.jar
[ERROR] urls[18] = file:/Users/heath.borders/.m2/repository/com/android/tools/ddms/ddmlib/22.0.2/ddmlib-22.0.2.jar
[ERROR] urls[19] = file:/Users/heath.borders/.m2/repository/org/bouncycastle/bcpkix-jdk15on/1.48/bcpkix-jdk15on-1.48.jar
[ERROR] urls[20] = file:/Users/heath.borders/.m2/repository/org/bouncycastle/bcprov-jdk15on/1.48/bcprov-jdk15on-1.48.jar
[ERROR] urls[21] = file:/Users/heath.borders/.m2/repository/org/sonatype/sisu/sisu-inject-bean/2.1.1/sisu-inject-bean-2.1.1.jar
[ERROR] urls[22] = file:/Users/heath.borders/.m2/repository/org/sonatype/sisu/sisu-guice/2.9.4/sisu-guice-2.9.4-no_aop.jar
[ERROR] urls[23] = file:/Users/heath.borders/.m2/repository/org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.jar
[ERROR] urls[24] = file:/Users/heath.borders/.m2/repository/org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar
[ERROR] urls[25] = file:/Users/heath.borders/.m2/repository/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar
[ERROR] urls[26] = file:/Users/heath.borders/.m2/repository/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar
[ERROR] urls[27] = file:/Users/heath.borders/.m2/repository/org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.jar
[ERROR] urls[28] = file:/Users/heath.borders/.m2/repository/emma/emma/2.0.5312/emma-2.0.5312.jar
[ERROR] urls[29] = file:/Users/heath.borders/.m2/repository/org/codehaus/plexus/plexus-archiver/2.3/plexus-archiver-2.3.jar
[ERROR] urls[30] = file:/Users/heath.borders/.m2/repository/junit/junit/3.8.1/junit-3.8.1.jar
[ERROR] urls[31] = file:/Users/heath.borders/.m2/repository/org/codehaus/plexus/plexus-io/2.0.6/plexus-io-2.0.6.jar
[ERROR] urls[32] = file:/Users/heath.borders/.m2/repository/org/codehaus/plexus/plexus-utils/3.0.10/plexus-utils-3.0.10.jar
[ERROR] urls[33] = file:/Users/heath.borders/.m2/repository/commons-jxpath/commons-jxpath/1.3/commons-jxpath-1.3.jar
[ERROR] urls[34] = file:/Users/heath.borders/.m2/repository/commons-io/commons-io/2.4/commons-io-2.4.jar
[ERROR] urls[35] = file:/Users/heath.borders/.m2/repository/org/ow2/asm/asm/4.1/asm-4.1.jar
[ERROR] urls[36] = file:/Users/heath.borders/.m2/repository/commons-lang/commons-lang/2.6/commons-lang-2.6.jar
[ERROR] urls[37] = file:/Users/heath.borders/.m2/repository/org/sonatype/aether/aether-util/1.13.1/aether-util-1.13.1.jar
[ERROR] urls[38] = file:/Users/heath.borders/.m2/repository/com/github/rtyley/android-screenshot-paparazzo/1.9/android-screenshot-paparazzo-1.9.jar
[ERROR] urls[39] = file:/Users/heath.borders/.m2/repository/com/madgag/animated-gif-lib/1.0/animated-gif-lib-1.0.jar
[ERROR] urls[40] = file:/Users/heath.borders/.m2/repository/com/github/rtyley/android-screenshot-celebrity/1.9/android-screenshot-celebrity-1.9.jar
[ERROR] Number of foreign imports: 1
[ERROR] import: Entry[import  from realm ClassRealm[project>com.octo.android:android-sample:0.0.1-SNAPSHOT, parent: ClassRealm[maven.api, parent: null]]]
[ERROR]
[ERROR] -----------------------------------------------------: org.sonatype.aether.RepositorySystem
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/AetherClassNotFound
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :android-sample
```
