### PR TITLE
Removed duplicated maven.compiler.plugin declarations

### DIFF
--- a/android-sample-tests/pom.xml
+++ b/android-sample-tests/pom.xml
@@ -90,9 +90,6 @@
 			</plugin>
 
 			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-			</plugin>
-			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
 				<executions>


### PR DESCRIPTION
Maven 3 doesn't like duplicate declarations either in the same file or same pom hierarchy [1].

```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for com.octo.android:android-sample-tests:apk:0.0.1-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-compiler-plugin @ line 113, column 12
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:build-helper-maven-plugin is missing. @ line 95, column 12
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```

[1] http://doc.nuxeo.com/display/public/CORG/Maven+coding+rules
