### PR TITLE
Fixed android sample tests.

### DIFF
--- a/android-sample-tests/src/main/java/com/octo/android/sample/test/HelloAndroidActivityTest.java
+++ b/android-sample-tests/src/main/java/com/octo/android/sample/test/HelloAndroidActivityTest.java
@@ -19,6 +19,13 @@ public class HelloAndroidActivityTest extends ActivityInstrumentationTestCase2<H
         super(HelloAndroidActivity.class);
     }
 
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        // workaround for https://code.google.com/p/dexmaker/issues/detail?id=2
+        System.setProperty("dexmaker.dexcache", getInstrumentation().getTargetContext().getCacheDir().toString());
+    }
+
     public void testActivity_not_null() {
         assertNotNull(getActivity());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 		<dexmaker.version>1.0</dexmaker.version>
 		<dexmaker-mockito.version>1.0</dexmaker-mockito.version>
 		<mockwebserver.version>20130303</mockwebserver.version>
-		<robotium.version>4.0</robotium.version>
+		<robotium.version>4.3.1</robotium.version>
 		<spoon.version>1.0.1</spoon.version>
 		<fest.version>1.0.3</fest.version>
 		<celebrity.version>1.8</celebrity.version>


### PR DESCRIPTION
Upgrading to robotium 4.3.1 fixed this exception (when run on a 4.4 emulator):

```
java.lang.RuntimeException: java.lang.ClassCastException: java.util.ArrayList cannot be cast to android.view.View[]
at com.jayway.android.robotium.solo.Searcher.searchFor(Searcher.java:127)
at com.jayway.android.robotium.solo.Waiter.waitForText(Waiter.java:383)
at com.jayway.android.robotium.solo.Clicker.clickOn(Clicker.java:352)
at com.jayway.android.robotium.solo.Solo.clickOnButton(Solo.java:742)
at com.octo.android.sample.test.HelloAndroidActivityFestAndroidTest.testCompute(HelloAndroidActivityFestAndroidTest.java:25)
at java.lang.reflect.Method.invokeNative(Native Method)
at android.test.InstrumentationTestCase.runMethod(InstrumentationTestCase.java:214)
at android.test.InstrumentationTestCase.runTest(InstrumentationTestCase.java:199)
at android.test.ActivityInstrumentationTestCase2.runTest(ActivityInstrumentationTestCase2.java:192)
at android.test.AndroidTestRunner.runTest(AndroidTestRunner.java:191)
at android.test.AndroidTestRunner.runTest(AndroidTestRunner.java:176)
at android.test.InstrumentationTestRunner.onStart(InstrumentationTestRunner.java:554)
at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:1701)
Caused by: java.lang.ClassCastException: java.util.ArrayList cannot be cast to android.view.View[]
at com.jayway.android.robotium.solo.ViewFetcher.getWindowDecorViews(ViewFetcher.java:389)
at com.jayway.android.robotium.solo.ViewFetcher.getAllViews(ViewFetcher.java:81)
at com.jayway.android.robotium.solo.ViewFetcher.getViews(ViewFetcher.java:189)
at com.jayway.android.robotium.solo.ViewFetcher.getCurrentViews(ViewFetcher.java:308)
at com.jayway.android.robotium.solo.ViewFetcher.getCurrentViews(ViewFetcher.java:295)
at com.jayway.android.robotium.solo.Searcher$1.call(Searcher.java:112)
at com.jayway.android.robotium.solo.Searcher$1.call(Searcher.java:106)
at com.jayway.android.robotium.solo.Searcher.searchFor(Searcher.java:203)
at com.jayway.android.robotium.solo.Searcher.searchFor(Searcher.java:125)
... 18 more
```
