### PR TITLE
Added missing build-helper-maven-plugin version.

### DIFF
--- a/android-sample-robolectric-tests/pom.xml
+++ b/android-sample-robolectric-tests/pom.xml
@@ -13,6 +13,10 @@
 	<packaging>apk</packaging>
 	<name>android-sample-robolectric-tests</name>
 
+        <properties>
+                <build-helper-maven-plugin.version>1.8</build-helper-maven-plugin.version>
+        </properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>android</groupId>
@@ -114,6 +118,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>${build-helper-maven-plugin.version}</version>
 				<executions>
 					<execution>
 						<id>add-source</id>


### PR DESCRIPTION
Fixes the following maven warning:

```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for com.octo.android:android-sample-robolectric-tests:apk:0.0.1-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:build-helper-maven-plugin is missing. @ line 114, column 12
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```
